### PR TITLE
pkg: switch Function package APIs from v1beta1 to v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ spec:
     kind: XR
   mode: Pipeline
   pipeline:
-  - step: 
+  - step:
     functionRef:
       name: function-pythonic
     input:
@@ -378,7 +378,7 @@ spec:
 ```
 #### functions.yaml
 ```yaml
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-pythonic

--- a/examples/.dev/functions.yaml
+++ b/examples/.dev/functions.yaml
@@ -2,7 +2,7 @@
 # Use this function yaml when developing and executing the function directly instead of in a container
 # E.g. `go run . --insecure --debug --address=":9443"`
 
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-pythonic

--- a/examples/aks-cluster/functions.yaml
+++ b/examples/aks-cluster/functions.yaml
@@ -1,4 +1,4 @@
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-pythonic

--- a/examples/eks-cluster/functions.yaml
+++ b/examples/eks-cluster/functions.yaml
@@ -1,4 +1,4 @@
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-pythonic

--- a/examples/filing-system/function.yaml
+++ b/examples/filing-system/function.yaml
@@ -1,4 +1,4 @@
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-pythonic

--- a/examples/function-go-templating/conditions/functions.yaml
+++ b/examples/function-go-templating/conditions/functions.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-environment-configs
@@ -7,7 +7,7 @@ spec:
   # This is ignored when using the Development runtime.
   package: xpkg.upbound.io/crossplane-contrib/function-environment-configs:v0.2.0
 ---
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-pythonic
@@ -17,7 +17,7 @@ metadata:
 spec:
   package: xpkg.upbound.io/crossplane-contrib/function-pythonic:v0.1.5
 ---
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-auto-ready

--- a/examples/function-go-templating/context/functions.yaml
+++ b/examples/function-go-templating/context/functions.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-environment-configs
@@ -7,7 +7,7 @@ spec:
   # This is ignored when using the Development runtime.
   package: xpkg.upbound.io/crossplane-contrib/function-environment-configs:v0.2.0
 ---
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-pythonic
@@ -17,7 +17,7 @@ metadata:
 spec:
   package: xpkg.upbound.io/crossplane-contrib/function-pythonic:v0.1.5
 ---
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-auto-ready

--- a/examples/function-go-templating/extra-resources/functions.yaml
+++ b/examples/function-go-templating/extra-resources/functions.yaml
@@ -1,4 +1,4 @@
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-pythonic

--- a/examples/function-go-templating/functions/fromYaml/functions.yaml
+++ b/examples/function-go-templating/functions/fromYaml/functions.yaml
@@ -1,4 +1,4 @@
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-pythonic

--- a/examples/function-go-templating/functions/getComposedResource/functions.yaml
+++ b/examples/function-go-templating/functions/getComposedResource/functions.yaml
@@ -1,4 +1,4 @@
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-pythonic

--- a/examples/function-go-templating/functions/getCompositeResource/functions.yaml
+++ b/examples/function-go-templating/functions/getCompositeResource/functions.yaml
@@ -1,4 +1,4 @@
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-pythonic

--- a/examples/function-go-templating/functions/getResourceCondition/functions.yaml
+++ b/examples/function-go-templating/functions/getResourceCondition/functions.yaml
@@ -1,4 +1,4 @@
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-pythonic

--- a/examples/function-go-templating/functions/include/functions.yaml
+++ b/examples/function-go-templating/functions/include/functions.yaml
@@ -1,4 +1,4 @@
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-pythonic

--- a/examples/function-go-templating/functions/toYaml/functions.yaml
+++ b/examples/function-go-templating/functions/toYaml/functions.yaml
@@ -1,4 +1,4 @@
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-pythonic

--- a/examples/function-go-templating/inline/functions.yaml
+++ b/examples/function-go-templating/inline/functions.yaml
@@ -1,4 +1,4 @@
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-pythonic

--- a/examples/function-go-templating/recursive/functions.yaml
+++ b/examples/function-go-templating/recursive/functions.yaml
@@ -1,4 +1,4 @@
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-pythonic

--- a/examples/get-started-app/functions.yaml
+++ b/examples/get-started-app/functions.yaml
@@ -1,4 +1,4 @@
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-pythonic

--- a/examples/helm-copy-secret/functions.yaml
+++ b/examples/helm-copy-secret/functions.yaml
@@ -1,4 +1,4 @@
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-pythonic

--- a/examples/import-existing-vpc/functions.yaml
+++ b/examples/import-existing-vpc/functions.yaml
@@ -1,4 +1,4 @@
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-pythonic

--- a/examples/single-purpose/functions.yaml
+++ b/examples/single-purpose/functions.yaml
@@ -1,4 +1,4 @@
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-pythonic

--- a/examples/usages-extra/functions.yaml
+++ b/examples/usages-extra/functions.yaml
@@ -1,4 +1,4 @@
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-pythonic

--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -1,4 +1,4 @@
-apiVersion: meta.pkg.crossplane.io/v1beta1
+apiVersion: meta.pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-pythonic


### PR DESCRIPTION
### Description

This PR updates Function package manifests to use `v1` instead of `v1beta1` for:

- `meta.pkg.crossplane.io`
- `pkg.crossplane.io`

Both `Function` and `FunctionRevision` already use `v1` as their storage version, so this change does not affect existing Crossplane installations when  Crossplane >= 1.17.x

The change only impacts newly built function packages, which will now be published using `v1`. Installing or upgrading these packages in an existing control plane works without disruption.

Related issue: https://github.com/crossplane/crossplane/issues/6947